### PR TITLE
Fix few things that was resolving failed deployment

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -47,7 +47,7 @@ Application.prototype.deploy = function deploy(args) {
                         winston.info('Create stack ' + stack + ' for ' + archive.appName + '-' + archive.version);
                         return environment.create(cname).then(environment.waitUntilStatusIsNot.bind(environment, 'Launching'));
                     } else {
-                      
+
                         winston.info('Deploying ' + archive.version + ' to ' + environment.name + '...');
                         return environment.deploy().then(environment.waitUntilStatusIsNot.bind(environment, 'Updating'));
                     }

--- a/lib/application.js
+++ b/lib/application.js
@@ -47,7 +47,7 @@ Application.prototype.deploy = function deploy(args) {
                         winston.info('Create stack ' + stack + ' for ' + archive.appName + '-' + archive.version);
                         return environment.create(cname).then(environment.waitUntilStatusIsNot.bind(environment, 'Launching'));
                     } else {
-
+                      
                         winston.info('Deploying ' + archive.version + ' to ' + environment.name + '...');
                         return environment.deploy().then(environment.waitUntilStatusIsNot.bind(environment, 'Updating'));
                     }
@@ -55,8 +55,7 @@ Application.prototype.deploy = function deploy(args) {
                 });
         })
         .then(environment.waitUtilHealthy.bind(environment))
-        .then(deploymentInfo.bind(null, archive, environment))
-        .catch(winston.error);
+        .then(deploymentInfo.bind(null, archive, environment));
 };
 
 module.exports = Application;

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -179,10 +179,12 @@ Environment.prototype.waitUtilHealthy = function () {
         function (err) {
             if (err) {
                 return defer.reject(err);
+            } else if (healthy === false) {
+                return defer.reject(new Error(this.name + ' is not healthy'));
             } else {
                 return defer.resolve(healthy);
             }
-        }
+        }.bind(this)
     );
     return defer.promise;
 };


### PR DESCRIPTION
I've remove the `catch` in the deploy method to let the promise be rejected if there is an exception. `catch` was catching the error, logging it but resolved the deploy promise whereas it should not.

I'm also rejecting promise if the the environment is not `Green`. This method was exiting after the `HEALTHY_TIMEOUT` expired with `healthy = false`, however it was resolved with this value instead of rejecting it. I believe that is the logic behaviour (otherwise `deploy` promise is resolved). Happy to discuss it.