### PR TITLE
Beanstalkify modification to allow setting of Beanstalk parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,9 @@ var application = new Application(
 application.deploy(
 {
     archiveFilePath: 'PATH TO ZIP FILE',
-    environmentName: 'CNAME',
+    applicationName: 'Application Name',
+    environmentName: 'Environment Name',
+    cnamePrefix: 'CNAME', 
     awsStackName: '64bit Amazon Linux 2015.03 v2.0.0 running Node.js',
     beanstalkConfig: [
         Beanstalk options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beanstalkify",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "AWS Elastic Beanstalk automation",
   "repository": {
     "type": "git",

--- a/src/archive.js
+++ b/src/archive.js
@@ -77,20 +77,24 @@ class Archive {
             throw new Error("Please make sure file name includes application name and version label separated by '-'. e.g. tech-website-1d595d3");
         }
         const versionLabel = baseName.pop(); // '4543cbf'
-        const applicationName = baseName.join('-'); // 'website-a'
-        return {archiveName, versionLabel, applicationName};
+        // const applicationName = baseName.join('-'); // 'website-a'
+        const bucketFolder = baseName;
+
+        return {archiveName, versionLabel, bucketFolder};
     }
 
     /**
      * Upload artifact to application and make application version available
      * @param {string} filePath - File path of the artifact
+     * @param {string} applicationName - Application name
      * @returns {Promise.<T>} Promise
      */
-    upload(filePath) {
+    upload(filePath, applicationName) {
 
         return q.async(function* () {
             // Step 1
-            const {archiveName, versionLabel, applicationName} = this.parse(filePath);
+            const {archiveName, versionLabel, bucketFolder} = this.parse(filePath);
+            const s3archive = bucketFolder + '/' + archiveName;
 
             // Step 2
             const ifAlreadyUploaded = yield this.alreadyUploaded(applicationName, versionLabel);
@@ -102,8 +106,8 @@ class Archive {
 
                 // Step 4,5,6
                 const {S3Bucket} = yield this.createStorageLocation();
-                yield this.uploadToS3(S3Bucket, archiveName, filePath);
-                yield this.makeApplicationVersionAvailableToBeanstalk(applicationName, versionLabel, archiveName, S3Bucket);
+                yield this.uploadToS3(S3Bucket, s3archive, filePath);
+                yield this.makeApplicationVersionAvailableToBeanstalk(applicationName, versionLabel, s3archive, S3Bucket);
             }
 
             return {archiveName, versionLabel, applicationName};

--- a/src/environment.js
+++ b/src/environment.js
@@ -35,12 +35,13 @@ class Environment {
     /**
      * @param {string} applicationName
      * @param {string} environmentName
+     * @param {string} cnamePrefix
      * @param {string} versionLabel
      * @param {object} stack
      * @param {object} config
      * @returns {*}
      */
-    create(applicationName, environmentName, versionLabel, stack, config) {
+    create(applicationName, environmentName, cnamePrefix, versionLabel, stack, config) {
         return q.async(function* () {
 
             const availability = yield this.checkDNSAvailability(environmentName);
@@ -57,7 +58,7 @@ class Environment {
                     EnvironmentName: environmentName,
                     SolutionStackName: stack,
                     OptionSettings: config,
-                    CNAMEPrefix: environmentName
+                    CNAMEPrefix: cnamePrefix
                 }
             );
 


### PR DESCRIPTION
- Added way to define application name and environment name
- Added ability to deploy multiple environments in a ElasticBeanstalk application
- Added a way to define CNAME prefix 
- Save artifact to S3 with environment name prefix. This will save the application versions inside the different environment folders 